### PR TITLE
Fix mergify config for main branch name

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,7 +1,7 @@
 pull_request_rules:
   - name: Automatic merge on approval
     conditions:
-      - base=master
+      - base=main
       - "#approved-reviews-by>=1"
       - "#review-requested=0"
       - "#changes-requested-reviews-by=0"


### PR DESCRIPTION
## Description

Fix the mergify config

## Why is this needed

The mergify config is referencing a `master` branch rather than `main`