### PR TITLE
Rework networking to also run inside kind+kubevirt

### DIFF
--- a/deploy/kubernetes/.gitignore
+++ b/deploy/kubernetes/.gitignore
@@ -1,0 +1,3 @@
+certs.yaml
+db-init.yaml
+envrc.yaml

--- a/deploy/kubernetes/boots.yaml
+++ b/deploy/kubernetes/boots.yaml
@@ -14,6 +14,18 @@ spec:
     type: Recreate
   template:
     metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |
+          [
+            {
+              "interface": "net1",
+              "ips": [
+                "192.168.1.1/29"
+              ],
+              "name": "tink",
+              "namespace": "default"
+            }
+          ]
       labels:
         app: boots
     spec:
@@ -50,7 +62,10 @@ spec:
             - name: DNS_SERVERS
               value: 8.8.8.8
             - name: DOCKER_REGISTRY
-              value: "$(PUBLIC_IP)"
+              valueFrom:
+                secretKeyRef:
+                  name: tinkerbell
+                  key: TINKERBELL_REGISTRY_IP
             - name: ELASTIC_SEARCH_URL
               value: "$(PUBLIC_IP):9200"
             - name: FACILITY_CODE
@@ -60,8 +75,11 @@ spec:
                   key: FACILITY
             - name: HTTP_BIND
               value: 0.0.0.0:80
-            - name: MIRROR_HOST
-              value: "$(PUBLIC_IP):8080"
+            - name: MIRROR_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: tinkerbell
+                  key: TINKERBELL_NGINX_URL
             - name: PACKET_ENV
               valueFrom:
                 secretKeyRef:
@@ -96,21 +114,29 @@ spec:
               value: 0.0.0.0:514
             - name: TFTP_BIND
               value: 0.0.0.0:69
+            - name: TINKERBELL_IP
+              valueFrom:
+                secretKeyRef:
+                  name: tinkerbell
+                  key: TINKERBELL_TINK_IP
             - name: TINKERBELL_CERT_URL
-              value: "http://$(PUBLIC_IP):42114/cert"
+              value: "http://$(TINKERBELL_IP):42114/cert"
             - name: TINKERBELL_GRPC_AUTHORITY
-              value: "$(PUBLIC_IP):42113"
+              value: "$(TINKERBELL_IP):42113"
           image: quay.io/tinkerbell/boots:sha-e81a291c
           imagePullPolicy: Always
           name: boots
           ports:
             - containerPort: 67
+              name: dhcp
               protocol: UDP
             - containerPort: 69
+              hostPort: 69
+              name: tftp
               protocol: UDP
             - containerPort: 80
-      dnsPolicy: ClusterFirstWithHostNet
-      hostNetwork: true
+              hostPort: 80
+              name: http
       restartPolicy: Always
 ---
 apiVersion: v1
@@ -121,17 +147,16 @@ metadata:
   name: boots
 spec:
   ports:
-    - name: "67"
+    - name: dhcp
       port: 67
       protocol: UDP
-      targetPort: 67
-    - name: "69"
+      targetPort: dhcp
+    - name: tftp
       port: 69
       protocol: UDP
-      targetPort: 69
-    - name: "80"
+      targetPort: tftp
+    - name: http
       port: 80
-      targetPort: 80
+      targetPort: http
   selector:
     app: boots
-  type: ClusterIP

--- a/deploy/kubernetes/db.yaml
+++ b/deploy/kubernetes/db.yaml
@@ -37,6 +37,7 @@ spec:
           name: db
           ports:
             - containerPort: 5432
+              name: psql
           readinessProbe:
             exec:
               command:
@@ -69,12 +70,11 @@ metadata:
   name: db
 spec:
   ports:
-    - name: "5432"
+    - name: psql
       port: 5432
-      targetPort: 5432
+      targetPort: psql
   selector:
     app: db
-  type: ClusterIP
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/deploy/kubernetes/dhcrelay.yaml
+++ b/deploy/kubernetes/dhcrelay.yaml
@@ -1,0 +1,60 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: dhcrelay
+  name: dhcrelay
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dhcrelay
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: dhcrelay
+    spec:
+      containers:
+        - args:
+            - -id
+            - $(DHCP_DOWNSTREAM_INTERFACE)
+            - -iu
+            - $(DHCP_UPSTREAM_INTERFACE)
+            - boots
+          env:
+            - name: DHCP_DOWNSTREAM_INTERFACE
+              valueFrom:
+                secretKeyRef:
+                  name: tinkerbell
+                  key: TINKERBELL_NETWORK_INTERFACE
+            - name: DHCP_UPSTREAM_INTERFACE
+              value: cni0
+          image: docker.io/modem7/dhcprelay:latest
+          imagePullPolicy: Always
+          name: dhcrelay
+          ports:
+            - containerPort: 67
+              hostPort: 67
+              name: dhcp
+              protocol: UDP
+      dnsPolicy: ClusterFirstWithHostNet
+      hostNetwork: true
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app: dhcrelay
+  name: dhcrelay
+spec:
+  ports:
+    - name: dhcp
+      port: 67
+      protocol: UDP
+      targetPort: dhcp
+  selector:
+    app: dhcrelay

--- a/deploy/kubernetes/hegel.yaml
+++ b/deploy/kubernetes/hegel.yaml
@@ -59,8 +59,11 @@ spec:
           name: hegel
           ports:
             - containerPort: 42115
+              hostPort: 42115
+              name: grpc
             - containerPort: 50061
               hostPort: 50061
+              name: http
       restartPolicy: Always
 ---
 apiVersion: v1
@@ -71,12 +74,11 @@ metadata:
   name: hegel
 spec:
   ports:
-    - name: "42115"
+    - name: grpc
       port: 42115
-      targetPort: 42115
-    - name: "50061"
+      targetPort: grpc
+    - name: http
       port: 50061
-      targetPort: 50061
+      targetPort: http
   selector:
     app: hegel
-  type: ClusterIP

--- a/deploy/kubernetes/nginx.yaml
+++ b/deploy/kubernetes/nginx.yaml
@@ -10,8 +10,22 @@ spec:
   selector:
     matchLabels:
       app: nginx
+  strategy:
+    type: Recreate
   template:
     metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |
+          [
+            {
+              "interface": "net1",
+              "ips": [
+                "192.168.1.2/29"
+              ],
+              "name": "tink",
+              "namespace": "default"
+            }
+          ]
       labels:
         app: nginx
     spec:
@@ -21,7 +35,8 @@ spec:
           name: nginx
           ports:
             - containerPort: 80
-          tty: true
+              hostPort: 8080
+              name: http
           volumeMounts:
             - mountPath: /usr/share/nginx/html/
               name: nginx-data
@@ -42,14 +57,12 @@ metadata:
   name: nginx
 spec:
   ports:
-    - name: "80"
-      nodePort: 8080
+    - name: http
       port: 80
-      targetPort: 80
+      targetPort: http
   selector:
     app: nginx
-  type: NodePort
-# ---
+#---
 # apiVersion: v1
 # kind: PersistentVolumeClaim
 # metadata:

--- a/deploy/kubernetes/registry.yaml
+++ b/deploy/kubernetes/registry.yaml
@@ -10,8 +10,22 @@ spec:
   selector:
     matchLabels:
       app: registry
+  strategy:
+    type: Recreate
   template:
     metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |
+          [
+            {
+              "interface": "net1",
+              "ips": [
+                "192.168.1.3/29"
+              ],
+              "name": "tink",
+              "namespace": "default"
+            }
+          ]
       labels:
         app: registry
     spec:
@@ -29,16 +43,6 @@ spec:
               value: /certs/server.pem
             - name: REGISTRY_HTTP_TLS_KEY
               value: /certs/server-key.pem
-            - name: A_REGISTRY_AUTH_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: tinkerbell
-                  key: TINKERBELL_REGISTRY_PASSWORD
-            - name: A_REGISTRY_AUTH_USERNAME
-              valueFrom:
-                secretKeyRef:
-                  name: tinkerbell
-                  key: TINKERBELL_REGISTRY_USERNAME
           image: docker.io/registry:2.7.0
           imagePullPolicy: Always
           livenessProbe:
@@ -49,6 +53,8 @@ spec:
           name: registry
           ports:
             - containerPort: 443
+              hostPort: 443
+              name: https
           readinessProbe:
             httpGet:
               scheme: HTTPS
@@ -107,13 +113,11 @@ metadata:
   name: registry
 spec:
   ports:
-    - name: "443"
-      nodePort: 443
+    - name: https
       port: 443
-      targetPort: 443
+      targetPort: https
   selector:
     app: registry
-  type: NodePort
 ---
 apiVersion: v1
 kind: PersistentVolumeClaim

--- a/deploy/kubernetes/tink-server.yaml
+++ b/deploy/kubernetes/tink-server.yaml
@@ -10,8 +10,22 @@ spec:
   selector:
     matchLabels:
       app: tink-server
+  strategy:
+    type: Recreate
   template:
     metadata:
+      annotations:
+        k8s.v1.cni.cncf.io/networks: |
+          [
+            {
+              "interface": "net1",
+              "ips": [
+                "192.168.1.4/29"
+              ],
+              "name": "tink",
+              "namespace": "default"
+            }
+          ]
       labels:
         app: tink-server
     spec:
@@ -78,7 +92,11 @@ spec:
           name: tink-server
           ports:
             - containerPort: 42113
+              hostPort: 42113
+              name: grpc
             - containerPort: 42114
+              hostPort: 42114
+              name: http
           readinessProbe:
             httpGet:
               scheme: HTTP
@@ -141,14 +159,11 @@ metadata:
   name: tink-server
 spec:
   ports:
-    - name: "42113"
-      nodePort: 42113
+    - name: grpc
       port: 42113
-      targetPort: 42113
-    - name: "42114"
-      nodePort: 42114
+      targetPort: grpc
+    - name: http
       port: 42114
-      targetPort: 42114
+      targetPort: http
   selector:
     app: tink-server
-  type: NodePort

--- a/deploy/kubevirt/README.md
+++ b/deploy/kubevirt/README.md
@@ -1,0 +1,122 @@
+# Deploying Tinkerbell Locally on Kubernetes with kind
+
+This directory is an effort to merge the [k8s-sandbox](https://github.com/tinkerbell/k8s-sandbox) and [tink-kindDev](https://github.com/detiber/tink/tree/kindDev) repositories to provide a unique set of Kubernetes manifests to deploy Tinkerbell either in Vagrant, Equinix Metal, Kind+KubeVirt or else.
+
+This is still very experimental and depends on shell scripts that will most likely screw up your system if ran outside a sandbox. You've been warned.
+
+The following commands are given as a guideline, not as a how-to.
+
+## Requirements
+
+### Fix networking on Docker
+
+Docker sets iptable's FORWARD policy to DROP. Set it to ACCEPT if running on Docker.
+
+```
+iptables -P FORWARD ACCEPT
+```
+
+### Fix networking on Kind
+
+```
+docker exec -it kind-control-plane sh -c "echo 0 >/proc/sys/net/bridge/bridge-nf-call-iptables"
+```
+
+### Fix CNI paths for k3s
+
+If using k3s, CNI binaries and configuration files aren't in standard location and Multus won't find them.
+
+```
+mkdir -p /etc/cni /opt/cni/bin
+
+echo "/var/lib/rancher/k3s/agent/etc/cni /etc/cni none defaults,bind 0 2" >> /etc/fstab
+echo "/var/lib/rancher/k3s/data/3a24132c2ddedfad7f599daf636840e8a14efd70d4992a1b3900d2617ed89893/bin /opt/cni/bin none defaults,bind 0 2" >> /etc/fstab
+
+mount /etc/cni
+mount /opt/cni/bin/
+```
+
+### Install missing CNI plugins
+
+Make sure that `bridge` and `static` plugins are installed, otherwise:
+
+```
+wget https://github.com/containernetworking/plugins/releases/download/v0.8.7/cni-plugins-linux-amd64-v0.8.7.tgz -O - | tar -xzC /opt/cni/bin/ ./bridge ./portmap ./static
+```
+
+### Install Multus
+
+```
+kubectl apply -f https://raw.githubusercontent.com/intel/multus-cni/master/images/multus-daemonset.yml
+kubectl apply -f multus-networks.yaml
+```
+
+### Install KubeVirt
+
+```
+kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/v0.34.2/kubevirt-operator.yaml
+
+# Skip if emulation is not required
+kubectl create configmap kubevirt-config -n kubevirt --from-literal debug.useEmulation=true
+
+kubectl apply -f https://github.com/kubevirt/kubevirt/releases/download/v0.34.2/kubevirt-cr.yaml
+```
+
+### Install Krew
+
+```
+TMPDIR="$(mktemp -d)"
+cd "$TMPDIR"
+curl -fsSLO "https://github.com/kubernetes-sigs/krew/releases/latest/download/krew.tar.gz"
+tar zxvf krew.tar.gz
+KREW=./krew-"$(uname | tr '[:upper:]' '[:lower:]')_$(uname -m | sed -e 's/x86_64/amd64/' -e 's/arm.*$/arm/')"
+"$KREW" install krew
+rm -rf "$TMPDIR"
+```
+
+### Install virtctl
+
+```
+kubectl krew install virt
+```
+
+### Install VNC Viewer
+
+```
+apt-get install -y xvnc4viewer
+```
+
+## Install Tinkerbell
+
+### Bootstrap
+
+```
+(
+  cd ../..
+
+  export TINKERBELL_HOST_IP=192.168.1.1
+  export TINKERBELL_NGINX_IP=192.168.1.2
+  export TINKERBELL_NGINX_URL=http://192.168.1.2
+  export TINKERBELL_REGISTRY_IP=192.168.1.3
+  export TINKERBELL_TINK_IP=192.168.1.4
+
+  ./generate-envrc.sh eth1 > .env
+  ./setup.sh
+)
+```
+
+### Install
+
+```
+kubectl apply -f ../kubernetes/
+```
+
+## Setup a workflow
+
+Coming soon...
+
+## Start the worker
+
+```
+kubectl apply -f worker.yaml
+```

--- a/deploy/kubevirt/multus-networks.yaml
+++ b/deploy/kubevirt/multus-networks.yaml
@@ -1,0 +1,38 @@
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: tink
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "tink",
+      "plugins": [
+        {
+          "bridge": "tink",
+          "ipam": {
+            "type": "static"
+          },
+          "type": "bridge"
+        }
+      ]
+    }
+---
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: tink-no-ip
+spec:
+  config: |
+    {
+      "cniVersion": "0.3.1",
+      "name": "tink-no-ip",
+      "plugins": [
+        {
+          "bridge": "tink",
+          "ipam": {},
+          "type": "bridge"
+        }
+      ]
+    }

--- a/deploy/kubevirt/worker.yaml
+++ b/deploy/kubevirt/worker.yaml
@@ -1,0 +1,43 @@
+---
+apiVersion: kubevirt.io/v1alpha3
+kind: VirtualMachineInstance
+metadata:
+  name: worker
+spec:
+  terminationGracePeriodSeconds: 30
+  domain:
+    clock:
+      utc: {}
+      timer:
+        hpet:
+          present: false
+        pit:
+          tickPolicy: delay
+        rtc:
+          tickPolicy: catchup
+    resources:
+      requests:
+        memory: 2048M
+    devices:
+      disks:
+        - name: emptydisk
+          disk:
+            bus: virtio
+          bootOrder: 2
+      interfaces:
+        - name: default
+          masquerade: {}
+        - name: tink
+          bridge: {}
+          macAddress: "08:00:27:00:00:01"
+          bootOrder: 1
+  networks:
+    - name: default
+      pod: {}
+    - name: tink
+      multus:
+        networkName: tink-no-ip
+  volumes:
+    - name: emptydisk
+      emptyDisk:
+        capacity: "10Gi"

--- a/deploy/tls/server-csr.in.json
+++ b/deploy/tls/server-csr.in.json
@@ -6,7 +6,9 @@
     "tinkerbell",
     "tink-server",
     "localhost",
-    "127.0.0.1"
+    "127.0.0.1",
+    "192.168.1.3",
+    "192.168.1.4"
   ],
   "key": {
     "algo": "rsa",

--- a/deploy/vagrant/Vagrantfile
+++ b/deploy/vagrant/Vagrantfile
@@ -31,7 +31,6 @@ Vagrant.configure('2') do |config|
     provisioner.vm.network "forwarded_port", guest: 42113, host: 42113
     provisioner.vm.network "forwarded_port", guest: 42114, host: 42114
 
-
     provisioner.vm.provider :libvirt do |lv, override|
       lv.memory = 2*1024
       lv.cpus = 2

--- a/generate-envrc.sh
+++ b/generate-envrc.sh
@@ -72,10 +72,17 @@ export TINKERBELL_CIDR=29
 #
 # The host IP should the first IP in the range, and the Nginx IP
 # should be the second address.
-export TINKERBELL_HOST_IP=192.168.1.1
+export TINKERBELL_HOST_IP=${TINKERBELL_HOST_IP:-192.168.1.1}
 
 # NGINX IP is used by provisioner to serve files required for iPXE boot
-export TINKERBELL_NGINX_IP=192.168.1.2
+export TINKERBELL_NGINX_IP=${TINKERBELL_NGINX_IP:-192.168.1.1}
+export TINKERBELL_NGINX_URL=${TINKERBELL_NGINX_URL:-http://192.168.1.1:8080}
+
+# Docker Registry IP
+export TINKERBELL_REGISTRY_IP=${TINKERBELL_REGISTRY_IP:-192.168.1.1}
+
+# Tink server IP
+export TINKERBELL_TINK_IP=${TINKERBELL_TINK_IP:-192.168.1.1}
 
 # Tink server username and password
 export TINKERBELL_TINK_USERNAME=admin

--- a/setup.sh
+++ b/setup.sh
@@ -388,9 +388,9 @@ start_components() (
 )
 
 create_secrets() (
-	awk '/^export /{print $2}' .env | sed "s/\([\"']\)\(.*\)\1\$/\2/g" | kubectl create secret generic tinkerbell --from-env-file=/dev/stdin --dry-run=client -o yaml > "$DEPLOYDIR/kubernetes/envrc.yaml"
-	kubectl create secret generic certs --from-file=deploy/state/certs/ --dry-run=client -o yaml > "$DEPLOYDIR/kubernetes/certs.yaml"
-	kubectl create configmap db-init --from-file=deploy/db/ --dry-run=client -o yaml > "$DEPLOYDIR/kubernetes/db-init.yaml"
+	awk '/^export /{print $2}' .env | sed "s/\([\"']\)\(.*\)\1\$/\2/g" | kubectl create secret generic tinkerbell --from-env-file=/dev/stdin --dry-run=client -o yaml >"$DEPLOYDIR/kubernetes/envrc.yaml"
+	kubectl create secret generic certs --from-file=deploy/state/certs/ --dry-run=client -o yaml >"$DEPLOYDIR/kubernetes/certs.yaml"
+	kubectl create configmap db-init --from-file=deploy/db/ --dry-run=client -o yaml >"$DEPLOYDIR/kubernetes/db-init.yaml"
 )
 
 install_secrets() (
@@ -453,7 +453,7 @@ check_prerequisites() (
 )
 
 whats_next() (
-	echo "$NEXT  1. Run 'kubectl apply -f /$DEPLOYDIR/deploy/kubernetes'."
+	echo "$NEXT  1. Run 'kubectl apply -f $DEPLOYDIR/kubernetes'."
 	echo "$BLANK 2. Try executing your fist workflow."
 	echo "$BLANK    Follow the steps described in https://tinkerbell.org/examples/hello-world/ to say 'Hello World!' with a workflow."
 )


### PR DESCRIPTION
## Description

This allows manifests to be deployed in either the normal Vagrant sandbox or Kind, using KubeVirt. There is also a README and some manifests to help deploying Tinkerbell in Kind even though it remains tricky.

## Why is this needed

This is a step forward to standardize deployment in Kubernetes. While k8s-sandbox is useful to test real-life scenarios, https://github.com/detiber/tink/tree/kindDev is great for development. By merging the two repositories, the idea is to make development and "prod" environments as similar as possible.

## How Has This Been Tested?

vagrant_test.go ran successfully and also validated manually. It also ran in Kind by modifying .env file as documented.

## How are existing users impacted? What migration steps/scripts do we need?

n/a

## Checklist:

I have:

- [x] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
