### PR TITLE
Add example workflow

### DIFF
--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -1,0 +1,17 @@
+# Example Workflow: Hello World
+
+This is an example workflow that will simply run the hello-world image from Docker Hub on the worker.
+
+First, make sure that the image is on the registry:
+
+```
+kubectl run skopeo -i --rm --restart=Never --image=none --overrides='{"spec":{"containers":[{"args":["copy","--dest-creds=$(REGISTRY_AUTH_USERNAME):$(REGISTRY_AUTH_PASSWORD)","--dest-tls-verify=false","docker://docker.io/hello-world:latest","docker://registry.default.svc.cluster.local/hello-world:latest"],"env":[{"name":"REGISTRY_AUTH_PASSWORD","valueFrom":{"secretKeyRef":{"name":"tinkerbell","key":"TINKERBELL_REGISTRY_PASSWORD"}}},{"name":"REGISTRY_AUTH_USERNAME","valueFrom":{"secretKeyRef":{"name":"tinkerbell","key":"TINKERBELL_REGISTRY_USERNAME"}}}],"image":"quay.io/containers/skopeo:v1.1.1","name":"skopeo"}]}}'
+```
+
+Then, push the hardware configuration, create the template and create the workflow:
+
+```
+kubectl exec -i $(kubectl get pod -l app=tink-cli -o name) -- tink hardware push < hardware-data.json
+TEMPLATE_ID=`kubectl exec -i $(kubectl get pod -l app=tink-cli -o name) -- tink template create --name hello-world < hello-world.yml | awk -F: '{print $2}'`
+kubectl exec -i $(kubectl get pod -l app=tink-cli -o name) -- tink workflow create -t ${TEMPLATE_ID} -r '{"device_1":"08:00:27:00:00:01"}'
+```

--- a/examples/hello-world/hardware-data.json
+++ b/examples/hello-world/hardware-data.json
@@ -1,0 +1,30 @@
+{
+  "id": "ce2e62ed-826f-4485-a39f-a82bb74338e2",
+  "metadata": {
+    "facility": {
+      "facility_code": "onprem"
+    },
+    "instance": {},
+    "state": ""
+  },
+  "network": {
+    "interfaces": [
+      {
+        "dhcp": {
+          "arch": "x86_64",
+          "ip": {
+            "address": "192.168.1.5",
+            "gateway": "192.168.1.1",
+            "netmask": "255.255.255.248"
+          },
+          "mac": "08:00:27:00:00:01",
+          "uefi": false
+        },
+        "netboot": {
+          "allow_pxe": true,
+          "allow_workflow": true
+        }
+      }
+    ]
+  }
+}

--- a/examples/hello-world/hello-world.yml
+++ b/examples/hello-world/hello-world.yml
@@ -1,0 +1,10 @@
+version: "0.1"
+name: hello_world_workflow
+global_timeout: 600
+tasks:
+  - name: "hello world"
+    worker: "{{.device_1}}"
+    actions:
+      - name: "hello_world"
+        image: hello-world
+        timeout: 60


### PR DESCRIPTION
## Description

This adds an `example/hello-world` directory that contains basic documentation, a hardware data file, and a workflow template to run the hello-world workflow.

## Why is this needed

It's convenient to have everything needed to run an example workflow in one place, ready to be used, instead of copy-pasting it from official documentation.

## How Has This Been Tested?

Ran manually in both vagrant and kind.

## How are existing users impacted? What migration steps/scripts do we need?

No impact

## Checklist:

I have:

- [ ] updated the documentation and/or roadmap (if required)
- [ ] added unit or e2e tests
- [ ] provided instructions on how to upgrade
