### PR TITLE
Run 'lint-install', address lint issues raised

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,12 @@ jobs:
         uses: actions/checkout@v2
         with:
           lfs: true
+      - name: Set up Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.17
+      - name: Lint
+        run: make lint
       - name: Install nix
         uses: cachix/install-nix-action@v12
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,204 @@
+# NOTE: This file is populated by the lint-install tool. Local adjustments may be overwritten.
+linters-settings:
+  cyclop:
+    # NOTE: This is a very high transitional threshold
+    max-complexity: 37
+    package-average: 34.0
+    skip-tests: true
+
+  gocognit:
+    # NOTE: This is a very high transitional threshold
+    min-complexity: 98
+
+  dupl:
+    threshold: 200
+
+  goconst:
+    min-len: 4
+    min-occurrences: 5
+    ignore-tests: true
+
+  gosec:
+    excludes:
+      - G107 # Potential HTTP request made with variable url
+      - G204 # Subprocess launched with function call as argument or cmd arguments
+      - G404 # Use of weak random number generator (math/rand instead of crypto/rand
+
+  errorlint:
+    # these are still common in Go: for instance, exit errors.
+    asserts: false
+
+  exhaustive:
+    default-signifies-exhaustive: true
+
+  nestif:
+    min-complexity: 8
+
+  nolintlint:
+    require-explanation: true
+    allow-unused: false
+    require-specific: true
+
+  revive:
+    ignore-generated-header: true
+    severity: warning
+    rules:
+      - name: atomic
+      - name: blank-imports
+      - name: bool-literal-in-expr
+      - name: confusing-naming
+      - name: constant-logical-expr
+      - name: context-as-argument
+      - name: context-keys-type
+      - name: deep-exit
+      - name: defer
+      - name: range-val-in-closure
+      - name: range-val-address
+      - name: dot-imports
+      - name: error-naming
+      - name: error-return
+      - name: error-strings
+      - name: errorf
+      - name: exported
+      - name: identical-branches
+      - name: if-return
+      - name: import-shadowing
+      - name: increment-decrement
+      - name: indent-error-flow
+      - name: indent-error-flow
+      - name: package-comments
+      - name: range
+      - name: receiver-naming
+      - name: redefines-builtin-id
+      - name: superfluous-else
+      - name: struct-tag
+      - name: time-naming
+      - name: unexported-naming
+      - name: unexported-return
+      - name: unnecessary-stmt
+      - name: unreachable-code
+      - name: unused-parameter
+      - name: var-declaration
+      - name: var-naming
+      - name: unconditional-recursion
+      - name: waitgroup-by-value
+
+  staticcheck:
+    go: "1.16"
+
+  unused:
+    go: "1.16"
+
+output:
+  sort-results: true
+
+linters:
+  disable-all: true
+  enable:
+    - asciicheck
+    - bodyclose
+    - cyclop
+    - deadcode
+    - dogsled
+    - dupl
+    - durationcheck
+    - errcheck
+    # errname is only available in golangci-lint v1.42.0+ - wait until v1.43 is available to settle
+    #- errname
+    - errorlint
+    - exhaustive
+    - exportloopref
+    - forcetypeassert
+    - gocognit
+    - goconst
+    - gocritic
+    - godot
+    - gofmt
+    - gofumpt
+    - gosec
+    - goheader
+    - goimports
+    - goprintffuncname
+    - gosimple
+    - govet
+    - ifshort
+    - importas
+    - ineffassign
+    - makezero
+    - misspell
+    - nakedret
+    - nestif
+    - nilerr
+    - noctx
+    - nolintlint
+    - predeclared
+    # disabling for the initial iteration of the linting tool
+    #- promlinter
+    - revive
+    - rowserrcheck
+    - sqlclosecheck
+    - staticcheck
+    - structcheck
+    - stylecheck
+    - thelper
+    - tparallel
+    - typecheck
+    - unconvert
+    - unparam
+    - unused
+    - varcheck
+    - wastedassign
+    - whitespace
+
+  # Disabled linters, due to being misaligned with Go practices
+  # - exhaustivestruct
+  # - gochecknoglobals
+  # - gochecknoinits
+  # - goconst
+  # - godox
+  # - goerr113
+  # - gomnd
+  # - lll
+  # - nlreturn
+  # - testpackage
+  # - wsl
+  # Disabled linters, due to not being relevant to our code base:
+  # - maligned
+  # - prealloc "For most programs usage of prealloc will be a premature optimization."
+  # Disabled linters due to bad error messages or bugs
+  # - tagliatelle
+
+issues:
+  # Excluding configuration per-path, per-linter, per-text and per-source
+  exclude-rules:
+    - path: _test\.go
+      linters:
+        - dupl
+        - errcheck
+        - forcetypeassert
+        - gocyclo
+        - gosec
+        - noctx
+
+    - path: .*cmd.*
+      linters:
+        - noctx
+
+    - path: main\.go
+      linters:
+        - noctx
+
+    - path: .*cmd.*
+      text: "deep-exit"
+
+    - path: main\.go
+      text: "deep-exit"
+
+    # This check is of questionable value
+    - linters:
+        - tparallel
+      text: "call t.Parallel on the top level as well as its subtests"
+
+  # Don't hide lint issues just because there are many of them
+  max-same-issues: 0
+  max-issues-per-linter: 0

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-
 # BEGIN: lint-install .
 # http://github.com/tinkerbell/lint-install
 
@@ -24,7 +23,7 @@ lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/l
 	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh")
 
 fix: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
-	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run test/_kind/ test/_vagrant  --fix
+	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run test/_kind/ test/_vagrant --fix
 	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh") -f diff | git apply -p2 -
 
 out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,40 @@
+
+# BEGIN: lint-install .
+# http://github.com/tinkerbell/lint-install
+
+GOLINT_VERSION ?= v1.42.0
+
+SHELLCHECK_VERSION ?= v0.7.2
+LINT_OS := $(shell uname)
+LINT_ARCH := $(shell uname -m)
+LINT_ROOT := $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
+
+# shellcheck and hadolint lack arm64 native binaries: rely on x86-64 emulation
+ifeq ($(LINT_OS),Darwin)
+	ifeq ($(LINT_ARCH),arm64)
+		LINT_ARCH=x86_64
+	endif
+endif
+
+LINT_LOWER_OS  = $(shell echo $(LINT_OS) | tr '[:upper:]' '[:lower:]')
+GOLINT_CONFIG:=$(LINT_ROOT)/.golangci.yml
+
+lint: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
+	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run test/_kind/ test/_vagrant
+	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh")
+
+fix: out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
+	out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH) run test/_kind/ test/_vagrant  --fix
+	out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck $(shell find . -name "*.sh") -f diff | git apply -p2 -
+
+out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)/shellcheck:
+	mkdir -p out/linters
+	curl -sSfL https://github.com/koalaman/shellcheck/releases/download/$(SHELLCHECK_VERSION)/shellcheck-$(SHELLCHECK_VERSION).$(LINT_LOWER_OS).$(LINT_ARCH).tar.xz | tar -C out/linters -xJf -
+	mv out/linters/shellcheck-$(SHELLCHECK_VERSION) out/linters/shellcheck-$(SHELLCHECK_VERSION)-$(LINT_ARCH)
+
+out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH):
+	mkdir -p out/linters
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b out/linters $(GOLINT_VERSION)
+	mv out/linters/golangci-lint out/linters/golangci-lint-$(GOLINT_VERSION)-$(LINT_ARCH)
+
+# END: lint-install .

--- a/test/_kind/kind_test.go
+++ b/test/_kind/kind_test.go
@@ -121,8 +121,6 @@ func TestKindSetupGuide(t *testing.T) {
 		t.Logf("%s", out)
 		t.Fatal(err)
 	}
-
-
 	cmd = exec.CommandContext(ctx, "/bin/sh", "-c", "kubectl apply -f ../../deploy/kubernetes")
 	out, err = cmd.CombinedOutput()
 	if err != nil {
@@ -153,6 +151,7 @@ func TestKindSetupGuide(t *testing.T) {
 
 	for ii := 0; ii < 5; ii++ {
 		resp, err := http.Get("http://localhost:42114/healthz")
+
 		if err != nil || resp.StatusCode != http.StatusOK {
 			if err != nil {
 				t.Logf("err tinkerbell healthcheck... retrying: %s", err)
@@ -161,6 +160,8 @@ func TestKindSetupGuide(t *testing.T) {
 			}
 			time.Sleep(10 * time.Second)
 		}
+
+		resp.Body.Close()
 	}
 
 	t.Log("Tinkerbell is up and running")
@@ -172,7 +173,7 @@ func TestKindSetupGuide(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = registerHardware(ctx)
+	err = registerHardware()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -248,7 +249,7 @@ tasks:
 	return resp.Id, nil
 }
 
-func registerHardware(ctx context.Context) error {
+func registerHardware() error {
 	data := []byte(`{
   "id": "ce2e62ed-826f-4485-a39f-a82bb74338e2",
   "metadata": {

--- a/test/_vagrant/vagrant_test.go
+++ b/test/_vagrant/vagrant_test.go
@@ -65,6 +65,7 @@ func TestVagrantSetupGuide(t *testing.T) {
 			}
 			time.Sleep(10 * time.Second)
 		}
+		resp.Body.Close()
 	}
 
 	t.Log("Tinkerbell is up and running")
@@ -76,7 +77,7 @@ func TestVagrantSetupGuide(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = registerHardware(ctx)
+	err = registerHardware()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -162,7 +163,7 @@ tasks:
 	return resp.Id, nil
 }
 
-func registerHardware(ctx context.Context) error {
+func registerHardware() error {
 	data := []byte(`{
   "id": "ce2e62ed-826f-4485-a39f-a82bb74338e2",
   "metadata": {


### PR DESCRIPTION
See https://github.com/tinkerbell/lint-install/issues/9

This adds new makefile rules: `lint` and `fix`, and addresses the following lint issues raised:

```
test/_kind/kind_test.go:124: File is not `gofumpt`-ed (gofumpt)

test/_kind/kind_test.go:125: File is not `gofmt`-ed with `-s` (gofmt)

test/_kind/kind_test.go:155:24: response body must be closed (bodyclose)
		resp, err := http.Get("http://localhost:42114/healthz")
		                     ^
test/_kind/kind_test.go:251:23: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func registerHardware(ctx context.Context) error {
                      ^
test/_vagrant/vagrant_test.go:59:24: response body must be closed (bodyclose)
		resp, err := http.Get("http://localhost:42114/healthz")
		                     ^
test/_vagrant/vagrant_test.go:165:23: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func registerHardware(ctx context.Context) error {
                      ^
```